### PR TITLE
Handle lifecycle of audio related objects to prevent memory leaks

### DIFF
--- a/library/src/main/java/com/voysis/recorder/AudioPlayer.kt
+++ b/library/src/main/java/com/voysis/recorder/AudioPlayer.kt
@@ -1,0 +1,31 @@
+package com.voysis.recorder
+
+import android.content.Context
+import android.media.MediaPlayer
+import com.voysis.sdk.R
+
+class AudioPlayer(private val context: Context,
+                  private var audioStart: MediaPlayer? = MediaPlayer.create(context, R.raw.voysis_on),
+                  private var audioStop: MediaPlayer? = MediaPlayer.create(context, R.raw.voysis_off)) {
+
+    fun playStartAudio(callback: () -> Unit) {
+        audioStart = audioStart ?: MediaPlayer.create(context, R.raw.voysis_on)
+        audioStart?.setOnCompletionListener {
+            callback()
+            audioStart?.release()
+            audioStart = null
+        }
+        audioStart?.setVolume(5f, 5f)
+        audioStart?.start()
+    }
+
+    fun playStopAudio() {
+        audioStop = audioStop ?: MediaPlayer.create(context, R.raw.voysis_off)
+        audioStop?.setOnCompletionListener {
+            audioStop?.release()
+            audioStop = null
+        }
+        audioStop?.setVolume(5f, 5f)
+        audioStop?.start()
+    }
+}

--- a/library/src/main/java/com/voysis/recorder/AudioRecorderImpl.kt
+++ b/library/src/main/java/com/voysis/recorder/AudioRecorderImpl.kt
@@ -3,21 +3,18 @@ package com.voysis.recorder
 import android.content.Context
 import android.media.AudioRecord
 import android.media.AudioRecord.STATE_UNINITIALIZED
-import android.media.MediaPlayer
 import android.util.Log
 import com.voysis.createAudioRecorder
-import com.voysis.sdk.R
+
 import java.nio.ByteBuffer
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
 class AudioRecorderImpl(context: Context,
-                        private val record: AudioRecord = createAudioRecorder(),
-                        private val audioStart: MediaPlayer? = MediaPlayer.create(context, R.raw.voysis_on),
-                        private val audioStop: MediaPlayer? = MediaPlayer.create(context, R.raw.voysis_off),
+                        private val player: AudioPlayer = AudioPlayer(context),
+                        private var record: AudioRecord? = null,
                         private val executor: Executor = Executors.newSingleThreadExecutor()) : AudioRecorder {
-
     private val inProgress = AtomicBoolean()
     private val maxBytes = 320000
 
@@ -28,16 +25,14 @@ class AudioRecorderImpl(context: Context,
     @Synchronized
     override fun start(callback: OnDataResponse) {
         stopRecorder()
+        record = record ?: createAudioRecorder()
         inProgress.set(true)
-        if (audioStart != null) {
-            audioStart.setOnCompletionListener { _ -> startRecording(callback) }
-            playAudio(audioStart)
-        } else {
-            startRecording(callback)
+        player.playStartAudio {
+            execute(callback)
         }
     }
 
-    private fun startRecording(callback: OnDataResponse) {
+    private fun execute(callback: OnDataResponse) {
         if (inProgress.get()) {
             executor.execute { write(callback) }
         }
@@ -46,14 +41,14 @@ class AudioRecorderImpl(context: Context,
     @Synchronized
     override fun stop() {
         stopRecorder()
-        if (audioStop != null && inProgress.get()) {
-            playAudio(audioStop)
+        if (inProgress.get()) {
+            player.playStopAudio()
             inProgress.set(false)
         }
     }
 
     private fun write(callback: OnDataResponse) {
-        record.startRecording()
+        record?.startRecording()
         callback.onRecordingStarted()
         val buf = ByteBuffer.allocate(BUFFER_SIZE)
         buf.clear()
@@ -62,7 +57,7 @@ class AudioRecorderImpl(context: Context,
         var limit = 0
         try {
             while (isRecording() && limit < maxBytes) {
-                bytesRead = record.read(buffer, 0, buffer.size)
+                bytesRead = record?.read(buffer, 0, buffer.size)!!
                 if ((bytesRead >= 0 || buf.position() > 0)) {
                     limit += bytesRead
                     buf.put(buffer, 0, bytesRead)
@@ -79,16 +74,12 @@ class AudioRecorderImpl(context: Context,
         callback.onComplete()
     }
 
-    private fun isRecording(): Boolean = record.recordingState == AudioRecord.RECORDSTATE_RECORDING
+    private fun isRecording(): Boolean = record?.recordingState == AudioRecord.RECORDSTATE_RECORDING
 
     private fun stopRecorder() {
-        if (record.state != STATE_UNINITIALIZED) {
-            record.stop()
+        if (record?.state != STATE_UNINITIALIZED) {
+            record?.stop()
+            record = null
         }
-    }
-
-    private fun playAudio(audio: MediaPlayer) {
-        audio.setVolume(5f, 5f)
-        audio.start()
     }
 }


### PR DESCRIPTION
Creating new mediaPlayer objects and an audioRecord object on a per request basis and releasing when finished to prevent memory leaks. To facilitate this I moved the soundbite start/stop code into its own class (AudioPlayer). This aligns android a bit more with iOS since we use this class structure on iOS. 