### PR TITLE
Add Feedback api to android library

### DIFF
--- a/library/src/main/java/com/voysis/api/Client.kt
+++ b/library/src/main/java/com/voysis/api/Client.kt
@@ -1,6 +1,6 @@
 package com.voysis.api
 
-import com.voysis.model.request.FeedbackEntity
+import com.voysis.model.request.FeedbackData
 import com.voysis.model.response.AudioQueryResponse
 import com.voysis.sevice.QueryFuture
 import java.io.IOException
@@ -36,5 +36,5 @@ interface Client {
      */
     fun refreshSessionToken(refreshToken: String): Future<String>
 
-    fun sendFeedback(path: String, feedback: FeedbackEntity, token: String): Future<String>
+    fun sendFeedback(path: String, feedback: FeedbackData, token: String): Future<String>
 }

--- a/library/src/main/java/com/voysis/api/Client.kt
+++ b/library/src/main/java/com/voysis/api/Client.kt
@@ -1,5 +1,6 @@
 package com.voysis.api
 
+import com.voysis.model.request.FeedbackEntity
 import com.voysis.model.response.AudioQueryResponse
 import com.voysis.sevice.QueryFuture
 import java.io.IOException
@@ -34,4 +35,6 @@ interface Client {
      * @return future containing Token json string or error.
      */
     fun refreshSessionToken(refreshToken: String): Future<String>
+
+    fun sendFeedback(path: String, feedback: FeedbackEntity, token: String): Future<String>
 }

--- a/library/src/main/java/com/voysis/api/Client.kt
+++ b/library/src/main/java/com/voysis/api/Client.kt
@@ -36,5 +36,5 @@ interface Client {
      */
     fun refreshSessionToken(refreshToken: String): Future<String>
 
-    fun sendFeedback(path: String, feedback: FeedbackData, token: String): Future<String>
+    fun sendFeedback(queryId: String, feedback: FeedbackData, token: String): Future<String>
 }

--- a/library/src/main/java/com/voysis/api/Service.kt
+++ b/library/src/main/java/com/voysis/api/Service.kt
@@ -1,6 +1,7 @@
 package com.voysis.api
 
 import com.voysis.events.Callback
+import com.voysis.model.request.FeedbackEntity
 import com.voysis.model.request.Token
 
 import java.io.IOException
@@ -42,6 +43,9 @@ interface Service {
      */
     @Throws(ExecutionException::class)
     fun refreshSessionToken(): Token
+
+    @Throws(ExecutionException::class)
+    fun sendFeedback(feedback: FeedbackEntity)
 
     /**
      * Call to manually stop recording audio and process request

--- a/library/src/main/java/com/voysis/api/Service.kt
+++ b/library/src/main/java/com/voysis/api/Service.kt
@@ -2,7 +2,7 @@ package com.voysis.api
 
 import com.voysis.events.Callback
 import com.voysis.events.VoysisException
-import com.voysis.model.request.FeedbackEntity
+import com.voysis.model.request.FeedbackData
 import com.voysis.model.request.Token
 
 import java.io.IOException
@@ -51,7 +51,7 @@ interface Service {
      * @throws VoysisException if query had not been made or token is invalid
      */
     @Throws(ExecutionException::class, VoysisException::class)
-    fun sendFeedback(feedback: FeedbackEntity)
+    fun sendFeedback(queryId: String, feedback: FeedbackData)
 
     /**
      * Call to manually stop recording audio and process request

--- a/library/src/main/java/com/voysis/api/Service.kt
+++ b/library/src/main/java/com/voysis/api/Service.kt
@@ -1,6 +1,7 @@
 package com.voysis.api
 
 import com.voysis.events.Callback
+import com.voysis.events.VoysisException
 import com.voysis.model.request.FeedbackEntity
 import com.voysis.model.request.Token
 
@@ -44,7 +45,12 @@ interface Service {
     @Throws(ExecutionException::class)
     fun refreshSessionToken(): Token
 
-    @Throws(ExecutionException::class)
+    /**
+     * Call this method send feedback following a successful query.
+     * @throws ExecutionException if reading/writing error occurs
+     * @throws VoysisException if query had not been made or token is invalid
+     */
+    @Throws(ExecutionException::class, VoysisException::class)
     fun sendFeedback(feedback: FeedbackEntity)
 
     /**

--- a/library/src/main/java/com/voysis/model/request/Request.kt
+++ b/library/src/main/java/com/voysis/model/request/Request.kt
@@ -30,6 +30,6 @@ data class Headers(@field:SerializedName("X-Voysis-Audio-Profile-Id") val audioP
 
 data class Token(var expiresAt: String, var token: String) : ApiResponse()
 
-data class FeedbackEntity(val durations: Duration = Duration()) : ApiRequest
+data class FeedbackData(val durations: Duration = Duration(), var rating: String? = null, var description: String? = null) : ApiRequest
 
 data class Duration(var vad: Long? = null, var complete: Long? = null)

--- a/library/src/main/java/com/voysis/model/request/Request.kt
+++ b/library/src/main/java/com/voysis/model/request/Request.kt
@@ -32,4 +32,4 @@ data class Token(var expiresAt: String, var token: String) : ApiResponse()
 
 data class FeedbackData(val durations: Duration = Duration(), var rating: String? = null, var description: String? = null) : ApiRequest
 
-data class Duration(var vad: Long? = null, var complete: Long? = null)
+data class Duration(var userStop: Long? = null, var vad: Long? = null, var complete: Long? = null)

--- a/library/src/main/java/com/voysis/model/request/Request.kt
+++ b/library/src/main/java/com/voysis/model/request/Request.kt
@@ -29,3 +29,7 @@ data class Headers(@field:SerializedName("X-Voysis-Audio-Profile-Id") val audioP
                    @field:SerializedName("Accept") val accept: String? = "application/vnd.voysisquery.v1+json")
 
 data class Token(var expiresAt: String, var token: String) : ApiResponse()
+
+data class FeedbackEntity(val durations: Duration = Duration()) : ApiRequest
+
+data class Duration(var vad: Long? = null, var complete: Long? = null)

--- a/library/src/main/java/com/voysis/rest/RestClient.kt
+++ b/library/src/main/java/com/voysis/rest/RestClient.kt
@@ -2,7 +2,7 @@ package com.voysis.rest
 
 import com.voysis.api.Client
 import com.voysis.events.VoysisException
-import com.voysis.model.request.FeedbackEntity
+import com.voysis.model.request.FeedbackData
 import com.voysis.model.response.AudioQueryResponse
 import com.voysis.sevice.AudioResponseFuture
 import com.voysis.sevice.Converter
@@ -56,7 +56,7 @@ class RestClient(private val converter: Converter, private val url: URL, private
         return future
     }
 
-    override fun sendFeedback(path: String, feedback: FeedbackEntity, token: String): Future<String> {
+    override fun sendFeedback(path: String, feedback: FeedbackData, token: String): Future<String> {
         setAuthorizationHeader(token)
         setAcceptHeader("application/vnd.voysisquery.v1+json")
         val future = QueryFuture()
@@ -66,6 +66,12 @@ class RestClient(private val converter: Converter, private val url: URL, private
             body["duration"] = mutableMapOf(
                     "vad" to it.vad,
                     "complete" to it.complete)
+        }
+        feedback.description.let {
+            body["description"] = "description"
+        }
+        feedback.rating.let {
+            body["rating"] = "rating"
         }
         val queriesUrl = URL(url, path)
         val request = createRequest(RequestBody.create(type, converter.toJson(body)), queriesUrl.toString())

--- a/library/src/main/java/com/voysis/sevice/ServiceImpl.kt
+++ b/library/src/main/java/com/voysis/sevice/ServiceImpl.kt
@@ -59,7 +59,7 @@ internal class ServiceImpl(private val client: Client,
         if (!tokenIsValid()) {
             refreshSessionToken()
         }
-        client.sendFeedback("/queries/$queryId/feedback", feedback, sessionToken!!.token)
+        client.sendFeedback(queryId, feedback, sessionToken!!.token)
     }
 
     override fun finish() {

--- a/library/src/main/java/com/voysis/sevice/ServiceImpl.kt
+++ b/library/src/main/java/com/voysis/sevice/ServiceImpl.kt
@@ -8,7 +8,7 @@ import com.voysis.events.Callback
 import com.voysis.events.Event
 import com.voysis.events.EventType
 import com.voysis.events.VoysisException
-import com.voysis.model.request.FeedbackEntity
+import com.voysis.model.request.FeedbackData
 import com.voysis.model.request.Token
 import com.voysis.model.response.AudioQueryResponse
 import com.voysis.model.response.AudioStreamResponse
@@ -31,7 +31,6 @@ internal class ServiceImpl(private val client: Client,
                            private val refreshToken: String) : Service {
     private var response: Future<String>? = null
     private var sessionToken: Token? = null
-    private var feedbackPath: String? = null
     private lateinit var pipe: Pipe
     override var state = State.IDLE
 
@@ -56,13 +55,11 @@ internal class ServiceImpl(private val client: Client,
     }
 
     @Throws(ExecutionException::class)
-    override fun sendFeedback(feedback: FeedbackEntity) {
-        if (feedbackPath == null) {
-            throw VoysisException("feedback path error")
-        } else if (sessionToken == null) {
-            throw VoysisException("token error")
+    override fun sendFeedback(queryId: String, feedback: FeedbackData) {
+        if (!tokenIsValid()) {
+            refreshSessionToken()
         }
-        client.sendFeedback(feedbackPath!!, feedback, sessionToken!!.token)
+        client.sendFeedback("/queries/$queryId/feedback", feedback, sessionToken!!.token)
     }
 
     override fun finish() {
@@ -115,7 +112,6 @@ internal class ServiceImpl(private val client: Client,
         response = client.createAudioQuery(context, sessionToken!!.token)
         val stringResponse = validateResponse(response!!.get())
         val audioQuery = converter.convertResponse(stringResponse, AudioQueryResponse::class.java)
-        feedbackPath = audioQuery.href.replace("audio", "feedback")
         callback.call(Event(audioQuery, EventType.AUDIO_QUERY_CREATED))
         return audioQuery
     }

--- a/library/src/main/java/com/voysis/websocket/WebSocketClient.kt
+++ b/library/src/main/java/com/voysis/websocket/WebSocketClient.kt
@@ -7,6 +7,7 @@ import com.voysis.api.StreamingStoppedReason.VAD_RECEIVED
 import com.voysis.events.PermissionDeniedException
 import com.voysis.events.VoysisException
 import com.voysis.model.request.ApiRequest
+import com.voysis.model.request.FeedbackEntity
 import com.voysis.model.request.RequestEntity
 import com.voysis.model.response.AudioQueryResponse
 import com.voysis.model.response.SocketResponse
@@ -45,6 +46,10 @@ internal class WebSocketClient(private val converter: Converter,
 
     override fun refreshSessionToken(refreshToken: String): Future<String> {
         return sendString("/tokens", null, refreshToken)
+    }
+
+    override fun sendFeedback(path: String, feedback: FeedbackEntity, token: String): Future<String> {
+        return sendString(path, feedback, token)
     }
 
     @Throws(IOException::class)

--- a/library/src/main/java/com/voysis/websocket/WebSocketClient.kt
+++ b/library/src/main/java/com/voysis/websocket/WebSocketClient.kt
@@ -48,8 +48,8 @@ internal class WebSocketClient(private val converter: Converter,
         return sendString("/tokens", null, refreshToken)
     }
 
-    override fun sendFeedback(path: String, feedback: FeedbackData, token: String): Future<String> {
-        return sendString(path, feedback, token)
+    override fun sendFeedback(queryId: String, feedback: FeedbackData, token: String): Future<String> {
+        return sendString("/queries/$queryId/feedback", feedback, token)
     }
 
     @Throws(IOException::class)

--- a/library/src/main/java/com/voysis/websocket/WebSocketClient.kt
+++ b/library/src/main/java/com/voysis/websocket/WebSocketClient.kt
@@ -7,7 +7,7 @@ import com.voysis.api.StreamingStoppedReason.VAD_RECEIVED
 import com.voysis.events.PermissionDeniedException
 import com.voysis.events.VoysisException
 import com.voysis.model.request.ApiRequest
-import com.voysis.model.request.FeedbackEntity
+import com.voysis.model.request.FeedbackData
 import com.voysis.model.request.RequestEntity
 import com.voysis.model.response.AudioQueryResponse
 import com.voysis.model.response.SocketResponse
@@ -48,7 +48,7 @@ internal class WebSocketClient(private val converter: Converter,
         return sendString("/tokens", null, refreshToken)
     }
 
-    override fun sendFeedback(path: String, feedback: FeedbackEntity, token: String): Future<String> {
+    override fun sendFeedback(path: String, feedback: FeedbackData, token: String): Future<String> {
         return sendString(path, feedback, token)
     }
 

--- a/library/src/test/java/com/voysis/android/core/impl/WebSocketClientTest.kt
+++ b/library/src/test/java/com/voysis/android/core/impl/WebSocketClientTest.kt
@@ -3,7 +3,7 @@ package com.voysis.android.core.impl
 import com.google.gson.Gson
 import com.nhaarman.mockito_kotlin.whenever
 import com.voysis.api.StreamingStoppedReason
-import com.voysis.model.request.FeedbackEntity
+import com.voysis.model.request.FeedbackData
 import com.voysis.sdk.ClientTest
 import com.voysis.sevice.Converter
 import com.voysis.websocket.WebSocketClient
@@ -70,7 +70,7 @@ class WebSocketClientTest : ClientTest() {
     @Test
     fun testSuccessfulFeedbackSent() {
         getResponseFromStringSend()
-        val future = webSocketClient.sendFeedback("" , FeedbackEntity(), token)
+        val future = webSocketClient.sendFeedback("" , FeedbackData(), token)
         val response = future.get()
         assertTrue(this.response.contains(response))
     }

--- a/library/src/test/java/com/voysis/android/core/impl/WebSocketClientTest.kt
+++ b/library/src/test/java/com/voysis/android/core/impl/WebSocketClientTest.kt
@@ -3,6 +3,7 @@ package com.voysis.android.core.impl
 import com.google.gson.Gson
 import com.nhaarman.mockito_kotlin.whenever
 import com.voysis.api.StreamingStoppedReason
+import com.voysis.model.request.FeedbackEntity
 import com.voysis.sdk.ClientTest
 import com.voysis.sevice.Converter
 import com.voysis.websocket.WebSocketClient
@@ -64,6 +65,14 @@ class WebSocketClientTest : ClientTest() {
         val future = webSocketClient.refreshSessionToken(token)
         val token = future.get()
         assertTrue(this.tokenResponseValid == token)
+    }
+
+    @Test
+    fun testSuccessfulFeedbackSent() {
+        getResponseFromStringSend()
+        val future = webSocketClient.sendFeedback("" , FeedbackEntity(), token)
+        val response = future.get()
+        assertTrue(this.response.contains(response))
     }
 
     @Test

--- a/library/src/test/java/com/voysis/sdk/ClientTest.kt
+++ b/library/src/test/java/com/voysis/sdk/ClientTest.kt
@@ -13,8 +13,8 @@ import java.util.Locale
 open class ClientTest {
 
     var headers = Headers("id", "agent")
-    val tokenResponseValid = """{"token":"1","expiresAt":"$expiresIn1Minute"}"""
-    var tokenResponseExpired = """{"token":"1","expiresAt":"$expiresIn25Seconds"}"""
+    val tokenResponseValid = """{"token":"token","expiresAt":"$expiresIn1Minute"}"""
+    var tokenResponseExpired = """{"token":"token","expiresAt":"$expiresIn25Seconds"}"""
     var response = """{"type":"response","entity":{"id":"2b95ff76-0de3-42d6-91c5-f61be84083bb","locale":"en-US","_links":{"self":{"href":"/queries/2b95ff76-0de3-42d6-91c5-f61be84083bb"},"audio":{"href":"/queries/2b95ff76-0de3-42d6-91c5-f61be84083bb/audio"}},"_embedded":{}},"requestId":"2","responseCode":201,"responseMessage":"Created"}"""
     var queryFutureResponse = """{"id":"12","locale":"en-US","conversationId":"1","queryType":"audio","audioQuery":{"mimeType":"audio/pcm"},"_links":{"self":{"href":"/queries/1"},"audio":{"href":"/queries/1/audio"}},"_embedded":{}}"""
     var notification = """{"type":"notification","notificationType":"query_complete","entity":{"id":"1","queryType":"audio","audioQuery":{"mimeType":"audio/pcm"},"intent":"Play Playlist","reply":{"text":"Playing My Favourite Music"},"entities":{"playlist_name":"My Favourite Music"},"_links":{"self":{"href":"/conversations/1/queries/1"},"audio":{"href":"/conversations/1/queries/1/audio"},"conversation":{"href":"/conversations/1"}}}}"""

--- a/library/src/test/java/com/voysis/sdk/ClientTest.kt
+++ b/library/src/test/java/com/voysis/sdk/ClientTest.kt
@@ -16,6 +16,7 @@ open class ClientTest {
     val tokenResponseValid = """{"token":"1","expiresAt":"$expiresIn1Minute"}"""
     var tokenResponseExpired = """{"token":"1","expiresAt":"$expiresIn25Seconds"}"""
     var response = """{"type":"response","entity":{"id":"2b95ff76-0de3-42d6-91c5-f61be84083bb","locale":"en-US","_links":{"self":{"href":"/queries/2b95ff76-0de3-42d6-91c5-f61be84083bb"},"audio":{"href":"/queries/2b95ff76-0de3-42d6-91c5-f61be84083bb/audio"}},"_embedded":{}},"requestId":"2","responseCode":201,"responseMessage":"Created"}"""
+    var queryFutureResponse = """{"id":"12","locale":"en-US","conversationId":"1","queryType":"audio","audioQuery":{"mimeType":"audio/pcm"},"_links":{"self":{"href":"/queries/1"},"audio":{"href":"/queries/1/audio"}},"_embedded":{}}"""
     var notification = """{"type":"notification","notificationType":"query_complete","entity":{"id":"1","queryType":"audio","audioQuery":{"mimeType":"audio/pcm"},"intent":"Play Playlist","reply":{"text":"Playing My Favourite Music"},"entities":{"playlist_name":"My Favourite Music"},"_links":{"self":{"href":"/conversations/1/queries/1"},"audio":{"href":"/conversations/1/queries/1/audio"},"conversation":{"href":"/conversations/1"}}}}"""
     var vad = """{"type":"notification","notificationType":"vad_stop"}"""
 

--- a/library/src/test/java/com/voysis/sdk/ServiceImplTest.kt
+++ b/library/src/test/java/com/voysis/sdk/ServiceImplTest.kt
@@ -12,8 +12,7 @@ import com.voysis.api.Client
 import com.voysis.api.State
 import com.voysis.api.StreamingStoppedReason.VAD_RECEIVED
 import com.voysis.events.Callback
-import com.voysis.events.VoysisException
-import com.voysis.model.request.FeedbackEntity
+import com.voysis.model.request.FeedbackData
 import com.voysis.recorder.AudioRecorder
 import com.voysis.recorder.OnDataResponse
 import com.voysis.sevice.AudioResponseFuture
@@ -108,19 +107,14 @@ class ServiceImplTest : ClientTest() {
         verify(client, times(1)).refreshSessionToken(anyOrNull())
     }
 
-    @Test(expected = VoysisException::class)
-    fun testInValidFeedback() {
-        serviceImpl.sendFeedback(FeedbackEntity())
-    }
-
     @Test
     fun testValidFeedback() {
         successfulExecutionResponses()
         answerRecordingStarted()
-        val feedback = FeedbackEntity()
+        val feedback = FeedbackData()
         serviceImpl.startAudioQuery(callback = callback)
-        serviceImpl.sendFeedback(feedback)
-        verify(client, times(1)).sendFeedback(eq("/queries/1/feedback"), eq(feedback), anyOrNull())
+        serviceImpl.sendFeedback("1", feedback)
+        verify(client, times(1)).sendFeedback(eq("/queries/1/feedback"), eq(feedback), eq("token"))
     }
 
     fun answerRecordingStarted() {

--- a/library/src/test/java/com/voysis/sdk/ServiceImplTest.kt
+++ b/library/src/test/java/com/voysis/sdk/ServiceImplTest.kt
@@ -114,7 +114,7 @@ class ServiceImplTest : ClientTest() {
         val feedback = FeedbackData()
         serviceImpl.startAudioQuery(callback = callback)
         serviceImpl.sendFeedback("1", feedback)
-        verify(client, times(1)).sendFeedback(eq("/queries/1/feedback"), eq(feedback), eq("token"))
+        verify(client, times(1)).sendFeedback(eq("1"), eq(feedback), eq("token"))
     }
 
     fun answerRecordingStarted() {

--- a/library/src/test/java/com/voysis/sdk/ServiceImplTest.kt
+++ b/library/src/test/java/com/voysis/sdk/ServiceImplTest.kt
@@ -4,7 +4,7 @@ import com.google.gson.Gson
 import com.nhaarman.mockito_kotlin.anyOrNull
 import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
@@ -12,6 +12,8 @@ import com.voysis.api.Client
 import com.voysis.api.State
 import com.voysis.api.StreamingStoppedReason.VAD_RECEIVED
 import com.voysis.events.Callback
+import com.voysis.events.VoysisException
+import com.voysis.model.request.FeedbackEntity
 import com.voysis.recorder.AudioRecorder
 import com.voysis.recorder.OnDataResponse
 import com.voysis.sevice.AudioResponseFuture
@@ -48,7 +50,7 @@ class ServiceImplTest : ClientTest() {
     @Before
     fun setup() {
         val converter = Converter(headers, Gson())
-        serviceImpl = spy(ServiceImpl(client, manager, converter, refreshToken))
+        serviceImpl = ServiceImpl(client, manager, converter, refreshToken)
     }
 
     @Test
@@ -64,7 +66,7 @@ class ServiceImplTest : ClientTest() {
 
     private fun successfulExecutionResponses() {
         doReturn(tokenResponseExpired).whenever(tokenFuture).get()
-        doReturn(response).whenever(audioQueryFuture).get()
+        doReturn(queryFutureResponse).whenever(audioQueryFuture).get()
         doReturn(notification).whenever(queryFuture).get()
         doReturn(VAD_RECEIVED).whenever(queryFuture).responseReason
         doReturn(tokenFuture).whenever(client).refreshSessionToken(anyOrNull())
@@ -104,6 +106,21 @@ class ServiceImplTest : ClientTest() {
         serviceImpl.startAudioQuery(callback = callback)
         serviceImpl.startAudioQuery(callback = callback)
         verify(client, times(1)).refreshSessionToken(anyOrNull())
+    }
+
+    @Test(expected = VoysisException::class)
+    fun testInValidFeedback() {
+        serviceImpl.sendFeedback(FeedbackEntity())
+    }
+
+    @Test
+    fun testValidFeedback() {
+        successfulExecutionResponses()
+        answerRecordingStarted()
+        val feedback = FeedbackEntity()
+        serviceImpl.startAudioQuery(callback = callback)
+        serviceImpl.sendFeedback(feedback)
+        verify(client, times(1)).sendFeedback(eq("/queries/1/feedback"), eq(feedback), anyOrNull())
     }
 
     fun answerRecordingStarted() {


### PR DESCRIPTION
- Added sendFeedback(feedbackEntity) to service interface and sendFeedback(path,feedback,token) to websocket and rest client. 

- Added FeedbackEntity object containing Duration object in constructor. This can be extended to facilitate any feedback type required.

- Storing feedbackPath in ServiceImpl. Using feedbackPath whenever sending feedback, if doesn't, exist throwing error.

- Added check that token and query path are valid before sending feedback. added tests, automatically sending feedback in test application.

Note: the android and iOS libraries public interfaces are a wee bit different. iOS returns the responseCode whereas android does not. I'm planning to correct this when we update the iOS library to use a callback future based approach the way android currently does.