### PR TITLE
Add optional userId field to serviceImpl.

### DIFF
--- a/library/src/main/java/com/voysis/api/Client.kt
+++ b/library/src/main/java/com/voysis/api/Client.kt
@@ -13,7 +13,7 @@ interface Client {
      * Call this method to create a new audioQueryRequest.
      *
      * @param context (optional) context response from previous request.
-     * @param userId (optional) uuid that uniquely identified a user.
+     * @param userId (optional) user ID that uniquely identified a user.
      * @param token session token assigned to the query.
      * @return future containing audioQueryResponse json string or error.
      */

--- a/library/src/main/java/com/voysis/api/Client.kt
+++ b/library/src/main/java/com/voysis/api/Client.kt
@@ -13,7 +13,7 @@ interface Client {
      * Call this method to create a new audioQueryRequest.
      *
      * @param context (optional) context response from previous request.
-     * @param userId (optional) uuid used to improve response quality over time.
+     * @param userId (optional) uuid that uniquely identified a user.
      * @param token session token assigned to the query.
      * @return future containing audioQueryResponse json string or error.
      */

--- a/library/src/main/java/com/voysis/api/Client.kt
+++ b/library/src/main/java/com/voysis/api/Client.kt
@@ -13,10 +13,11 @@ interface Client {
      * Call this method to create a new audioQueryRequest.
      *
      * @param context (optional) context response from previous request.
+     * @param userId (optional) uuid used to improve response quality over time.
      * @param token session token assigned to the query.
      * @return future containing audioQueryResponse json string or error.
      */
-    fun createAudioQuery(context: Map<String, Any>? = null, token: String): Future<String>
+    fun createAudioQuery(context: Map<String, Any>? = null, userId: String?, token: String): Future<String>
 
     /**
      * Call this method to stream audio to server and return an audioStreamResponse

--- a/library/src/main/java/com/voysis/api/Service.kt
+++ b/library/src/main/java/com/voysis/api/Service.kt
@@ -34,6 +34,16 @@ interface Service {
     fun startAudioQuery(context: Map<String, Any>? = null, callback: Callback)
 
     /**
+     * Call to manually stop recording audio and process request
+     */
+    fun finish()
+
+    /**
+     * Call to cancel request.
+     */
+    fun cancel()
+
+    /**
      * Call this method to manually refresh the session token.
      * Note: The sdk automatically handles checking/refreshing and storing the session token.
      * This method is called internally by `startAudioQuery`.
@@ -52,16 +62,6 @@ interface Service {
      */
     @Throws(ExecutionException::class, VoysisException::class)
     fun sendFeedback(queryId: String, feedback: FeedbackData)
-
-    /**
-     * Call to manually stop recording audio and process request
-     */
-    fun finish()
-
-    /**
-     * Call to cancel request.
-     */
-    fun cancel()
 }
 
 enum class State {

--- a/library/src/main/java/com/voysis/api/ServiceProvider.kt
+++ b/library/src/main/java/com/voysis/api/ServiceProvider.kt
@@ -31,7 +31,7 @@ class ServiceProvider {
              audioRecorder: AudioRecorder = AudioRecorderImpl(context)): Service {
         val converter = Converter(getHeaders(context), Gson())
         val client = createClient(config, generateOkHttpClient(okClient), converter)
-        return ServiceImpl(client, audioRecorder, converter, config.refreshToken)
+        return ServiceImpl(client, audioRecorder, converter, config.userId, config.refreshToken)
     }
 
     /**

--- a/library/src/main/java/com/voysis/model/request/Request.kt
+++ b/library/src/main/java/com/voysis/model/request/Request.kt
@@ -19,7 +19,7 @@ data class SocketRequest(val restUri: String? = null,
 data class RequestEntity(val context: Map<String, Any>? = null,
                          val queryType: String? = "audio",
                          val audioQuery: Query? = Query("audio/pcm"),
-                         val id: String? = "",
+                         val userId: String? = null,
                          val locale: String = "en-US") : ApiRequest
 
 data class Headers(@field:SerializedName("X-Voysis-Audio-Profile-Id") val audioProfileId: String,

--- a/library/src/main/java/com/voysis/rest/RestClient.kt
+++ b/library/src/main/java/com/voysis/rest/RestClient.kt
@@ -32,7 +32,7 @@ class RestClient(private val converter: Converter, private val url: URL, private
             .addHeader("Accept", acceptJson)
             .addHeader("User-Agent", converter.headers.userAgent)
 
-    override fun createAudioQuery(context: Map<String, Any>?, token: String): Future<String> {
+    override fun createAudioQuery(context: Map<String, Any>?, userId: String?, token: String): Future<String> {
         setAuthorizationHeader(token)
         setAcceptHeader("application/vnd.voysisquery.v1+json")
         val future = QueryFuture()
@@ -41,6 +41,9 @@ class RestClient(private val converter: Converter, private val url: URL, private
                 "queryType" to "audio",
                 "audioQuery" to mapOf("mimeType" to "audio/pcm")
         )
+        userId?.let {
+            body["userId"] = userId
+        }
         context?.let {
             body["context"] = context
         }

--- a/library/src/main/java/com/voysis/websocket/WebSocketClient.kt
+++ b/library/src/main/java/com/voysis/websocket/WebSocketClient.kt
@@ -40,8 +40,8 @@ internal class WebSocketClient(private val converter: Converter,
         const val CLOSING = "closing"
     }
 
-    override fun createAudioQuery(context: Map<String, Any>?, token: String): Future<String> {
-        return sendString("/queries", RequestEntity(context = context), token)
+    override fun createAudioQuery(context: Map<String, Any>?, userId: String?, token: String): Future<String> {
+        return sendString("/queries", RequestEntity(context = context, userId = userId), token)
     }
 
     override fun refreshSessionToken(refreshToken: String): Future<String> {

--- a/library/src/test/java/com/voysis/android/core/impl/WebSocketClientTest.kt
+++ b/library/src/test/java/com/voysis/android/core/impl/WebSocketClientTest.kt
@@ -42,6 +42,7 @@ class WebSocketClientTest : ClientTest() {
     private lateinit var webSocketClient: WebSocketClient
     private val context = hashMapOf("test" to "test")
     private val token = "token"
+    private val userId = "userId"
 
     @Before
     @Throws(MalformedURLException::class)
@@ -55,7 +56,7 @@ class WebSocketClientTest : ClientTest() {
     @Throws(Exception::class)
     fun testSuccessfulCreateAudioQuery() {
         getResponseFromStringSend()
-        val future = webSocketClient.createAudioQuery(context, token)
+        val future = webSocketClient.createAudioQuery(context, userId, token)
         val response = future.get()
         assertTrue(this.response.contains(response))
     }
@@ -70,7 +71,7 @@ class WebSocketClientTest : ClientTest() {
     @Test
     fun testSuccessfulFeedbackSent() {
         getResponseFromStringSend()
-        val future = webSocketClient.sendFeedback("" , FeedbackData(), token)
+        val future = webSocketClient.sendFeedback("", FeedbackData(), token)
         val response = future.get()
         assertTrue(this.response.contains(response))
     }
@@ -91,7 +92,7 @@ class WebSocketClientTest : ClientTest() {
     @Throws(Exception::class)
     fun testCloseWhileSessionInProgress() {
         getCloseResponseFromStringSend()
-        val future = webSocketClient.createAudioQuery(context, token)
+        val future = webSocketClient.createAudioQuery(context, userId, token)
         val response = future.get()
         assertEquals(response, "closing")
     }
@@ -100,7 +101,7 @@ class WebSocketClientTest : ClientTest() {
     @Throws(Exception::class)
     fun testFailWhileSessionInProgress() {
         getFailureResponseFromStringSend()
-        val future = webSocketClient.createAudioQuery(context, token)
+        val future = webSocketClient.createAudioQuery(context, userId, token)
         future.get()
     }
 
@@ -120,7 +121,7 @@ class WebSocketClientTest : ClientTest() {
     }
 
     private fun getResponseFromByteStringSendWithVad() {
-        webSocketClient.createAudioQuery(context, token)
+        webSocketClient.createAudioQuery(context, userId, token)
         doAnswer {
             argumentCaptor.value.onMessage(webSocket, vad)
             argumentCaptor.value.onMessage(webSocket, notification)

--- a/library/src/test/java/com/voysis/sdk/ServiceImplRestTest.kt
+++ b/library/src/test/java/com/voysis/sdk/ServiceImplRestTest.kt
@@ -56,7 +56,7 @@ class ServiceImplRestTest : ClientTest() {
     @Throws(Exception::class)
     fun testSuccessCreateAudioQuery() {
         doReturn("result").whenever(body).string()
-        val future = restClient.createAudioQuery(token = "token")
+        val future = restClient.createAudioQuery(userId = "userId", token = "token")
         doReturn(true).whenever(networkResponse).isSuccessful
         voysisEventArgumentCaptor.value.onResponse(call, networkResponse)
         assertEquals(future.get(), "result")

--- a/library/src/test/java/com/voysis/sdk/ServiceImplTest.kt
+++ b/library/src/test/java/com/voysis/sdk/ServiceImplTest.kt
@@ -45,11 +45,12 @@ class ServiceImplTest : ClientTest() {
 
     private lateinit var serviceImpl: ServiceImpl
     private val refreshToken = "refreshToken"
+    private val userId = "userId"
 
     @Before
     fun setup() {
         val converter = Converter(headers, Gson())
-        serviceImpl = ServiceImpl(client, manager, converter, refreshToken)
+        serviceImpl = ServiceImpl(client, manager, converter, userId, refreshToken)
     }
 
     @Test
@@ -69,7 +70,7 @@ class ServiceImplTest : ClientTest() {
         doReturn(notification).whenever(queryFuture).get()
         doReturn(VAD_RECEIVED).whenever(queryFuture).responseReason
         doReturn(tokenFuture).whenever(client).refreshSessionToken(anyOrNull())
-        doReturn(audioQueryFuture).whenever(client).createAudioQuery(any(), anyOrNull())
+        doReturn(audioQueryFuture).whenever(client).createAudioQuery(any(), anyOrNull(), anyOrNull())
         doReturn(queryFuture).whenever(client).streamAudio(anyOrNull(), anyOrNull())
     }
 


### PR DESCRIPTION
- Passing userID field into serviceImpl. 

- Adding userId field to createAudioQuery in websocket and rest clients. 

- Reordered methods to match interface ordering.

- Replaced unused id field in RequestEntity with userId field.