### PR TITLE
Fix gson proguard issue. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Step 2. Add the dependency
 	}
 	
 
+Proguard
+-------------
+
+If using proguard you will need add the recommended proguard rules for [okhttp](https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro)
+
+
 Local Build
 -------------
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,16 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+# JSR 305 annotations are for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
+-dontwarn org.codehaus.mojo.animal_sniffer.*
+
+# OkHttp platform used only on JVM and when Conscrypt dependency is available.
+-dontwarn okhttp3.internal.platform.ConscryptPlatform
+
+-dontwarn okio.**

--- a/library/src/main/java/com/voysis/model/request/Request.kt
+++ b/library/src/main/java/com/voysis/model/request/Request.kt
@@ -10,19 +10,19 @@ import com.voysis.model.response.TextQuery
  */
 interface ApiRequest
 
-data class SocketRequest(val restUri: String? = null,
-                         val headers: Headers? = null,
-                         val entity: ApiRequest? = null,
-                         val requestId: String? = null,
-                         val type: String? = "request",
-                         val method: String? = "POST")
+data class SocketRequest(@field:SerializedName("restUri") val restUri: String? = null,
+                         @field:SerializedName("headers") val headers: Headers? = null,
+                         @field:SerializedName("entity") val entity: ApiRequest? = null,
+                         @field:SerializedName("requestId") val requestId: String? = null,
+                         @field:SerializedName("type") val type: String? = "request",
+                         @field:SerializedName("method") val method: String? = "POST")
 
-data class RequestEntity(val context: Map<String, Any>? = null,
-                         val queryType: String? = "audio",
-                         val audioQuery: AudioQuery? = null,
-                         val textQuery: TextQuery? = null,
-                         val userId: String? = null,
-                         val locale: String = "en-US") : ApiRequest
+data class RequestEntity(@field:SerializedName("context") val context: Map<String, Any>? = null,
+                         @field:SerializedName("queryType") val queryType: String? = "audio",
+                         @field:SerializedName("audioQuery") val audioQuery: AudioQuery? = null,
+                         @field:SerializedName("textQuery") val textQuery: TextQuery? = null,
+                         @field:SerializedName("userId") val userId: String? = null,
+                         @field:SerializedName("locale") val locale: String = "en-US") : ApiRequest
 
 data class Headers(@field:SerializedName("X-Voysis-Audio-Profile-Id") val audioProfileId: String,
                    @field:SerializedName("User-Agent") val userAgent: String,
@@ -30,8 +30,13 @@ data class Headers(@field:SerializedName("X-Voysis-Audio-Profile-Id") val audioP
                    @field:SerializedName("X-Voysis-Ignore-Vad") val xVoysisIgnoreVad: Boolean? = false,
                    @field:SerializedName("Accept") val accept: String? = "application/vnd.voysisquery.v1+json")
 
-data class Token(var expiresAt: String, var token: String) : ApiResponse()
+data class Token(@field:SerializedName("expiresAt") var expiresAt: String,
+                 @field:SerializedName("token") var token: String) : ApiResponse()
 
-data class FeedbackData(val durations: Duration = Duration(), var rating: String? = null, var description: String? = null) : ApiRequest
+data class FeedbackData(@field:SerializedName("durations") val durations: Duration = Duration(),
+                        @field:SerializedName("rating") var rating: String? = null,
+                        @field:SerializedName("description") var description: String? = null) : ApiRequest
 
-data class Duration(var userStop: Long? = null, var vad: Long? = null, var complete: Long? = null)
+data class Duration(@field:SerializedName("userStop") var userStop: Long? = null,
+                    @field:SerializedName("vad") var vad: Long? = null,
+                    @field:SerializedName("complete") var complete: Long? = null)

--- a/library/src/main/java/com/voysis/model/response/QueryResponse.kt
+++ b/library/src/main/java/com/voysis/model/response/QueryResponse.kt
@@ -1,6 +1,9 @@
 package com.voysis.model.response
 
-data class QueryResponse(var audioQuery: AudioQuery? = null, var queryType: String? = null) : ApiResponse() {
+import com.google.gson.annotations.SerializedName
+
+data class QueryResponse(@field:SerializedName("audioQuery") var audioQuery: AudioQuery? = null,
+                         @field:SerializedName("queryType") var queryType: String? = null) : ApiResponse() {
     val href: String
         get() = links.audio!!.href!!
 }

--- a/library/src/main/java/com/voysis/model/response/Response.kt
+++ b/library/src/main/java/com/voysis/model/response/Response.kt
@@ -8,26 +8,30 @@ import com.google.gson.annotations.SerializedName
 open class ApiResponse {
     @SerializedName("_links")
     lateinit var links: Links
+    @SerializedName("id")
     lateinit var id: String
 }
 
-data class SocketResponse<out T>(val notificationType: String? = null,
-                                 val responseMessage: String? = null,
-                                 val requestId: String? = null,
-                                 val responseCode: Int = 0,
-                                 val type: String? = null,
-                                 val entity: T? = null)
+data class SocketResponse<out T>(@field:SerializedName("notificationType") val notificationType: String? = null,
+                                 @field:SerializedName("responseMessage") val responseMessage: String? = null,
+                                 @field:SerializedName("requestId") val requestId: String? = null,
+                                 @field:SerializedName("responseCode") val responseCode: Int = 0,
+                                 @field:SerializedName("type") val type: String? = null,
+                                 @field:SerializedName("entity") val entity: T? = null)
 
-data class Links(val self: Self? = null, val queries: Queries? = null, val audio: Audio? = null)
+data class Links(@field:SerializedName("self") val self: Self? = null,
+                 @field:SerializedName("queries") val queries: Queries? = null,
+                 @field:SerializedName("audio") val audio: Audio? = null)
 
-data class TextQuery(val text: String? = null)
+data class TextQuery(@field:SerializedName("text") val text: String? = null)
 
-data class AudioQuery(val mimeType: String? = "audio/pcm;bits=16;rate=16000")
+data class AudioQuery(@field:SerializedName("mimeType") val mimeType: String? = "audio/pcm;bits=16;rate=16000")
 
-data class Reply(val text: String? = null, val audioUri: String? = null)
+data class Reply(@field:SerializedName("text") val text: String? = null,
+                 @field:SerializedName("audioUri") val audioUri: String? = null)
 
-data class Queries(val href: String? = null)
+data class Queries(@field:SerializedName("href") val href: String? = null)
 
-data class Audio(val href: String? = null)
+data class Audio(@field:SerializedName("href") val href: String? = null)
 
-data class Self(val href: String? = null)
+data class Self(@field:SerializedName("href") val href: String? = null)

--- a/library/src/main/java/com/voysis/model/response/StreamResponse.kt
+++ b/library/src/main/java/com/voysis/model/response/StreamResponse.kt
@@ -1,13 +1,14 @@
 package com.voysis.model.response
 
 import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
 
-data class StreamResponse(private val entities: Any? = null,
-                          val context: Map<String, Any>? = null,
-                          val audioQuery: AudioQuery? = null,
-                          val textQuery: TextQuery? = null,
-                          val reply: Reply? = null,
-                          val intent: String? = null) : ApiResponse() {
+data class StreamResponse(@field:SerializedName("entities") private val entities: Any? = null,
+                          @field:SerializedName("context") val context: Map<String, Any>? = null,
+                          @field:SerializedName("audioQuery") val audioQuery: AudioQuery? = null,
+                          @field:SerializedName("textQuery") val textQuery: TextQuery? = null,
+                          @field:SerializedName("reply") val reply: Reply? = null,
+                          @field:SerializedName("intent") val intent: String? = null) : ApiResponse() {
     /**
      * @param clazz class object
      * @param <T> respone type


### PR DESCRIPTION
When we enable proguard (android code obfuscation tool) requests fail. This occurs because gson is obfuscating json field names. To fix this we need to add @SerializedName to all request,response fields.

- Added proguard rules for okhtttp and okio for test application. 

- Added SerializedName annotation for fields.