### PR TITLE
Fix memory leak time format

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -36,7 +36,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.jakewharton.threetenabp:threetenabp:1.1.1'
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     testImplementation 'com.nhaarman:mockito-kotlin-kt1.1:1.6.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 28
         versionCode 5
-        versionName "2.0.11"
+        versionName "2.0.12"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/library/src/main/java/com/voysis/Utils.kt
+++ b/library/src/main/java/com/voysis/Utils.kt
@@ -10,6 +10,9 @@ import com.voysis.model.request.Headers
 import com.voysis.sdk.BuildConfig
 import okhttp3.OkHttpClient
 import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
@@ -108,4 +111,18 @@ private fun getBufferSize(sampleRate: Int): Int {
         minBufferSizeInBytes = DEFAULT_BUFFER_SIZE
     }
     return 4 * minBufferSizeInBytes
+}
+
+fun generateISODate(expiresAt: String): Date {
+    val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.ENGLISH)
+    return format.parse(expiresAt)
+}
+
+fun generateRFCDate(expiresAt: String): Date {
+    var local = expiresAt
+    if (expiresAt.endsWith("Z")) {
+        local = expiresAt.replace("Z", "+0000")
+    }
+    val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.ENGLISH)
+    return format.parse(local)
 }

--- a/library/src/main/java/com/voysis/api/ServiceProvider.kt
+++ b/library/src/main/java/com/voysis/api/ServiceProvider.kt
@@ -2,7 +2,6 @@ package com.voysis.api
 
 import android.content.Context
 import com.google.gson.Gson
-import com.jakewharton.threetenabp.AndroidThreeTen
 import com.voysis.generateOkHttpClient
 import com.voysis.getHeaders
 import com.voysis.recorder.AudioRecorder
@@ -33,7 +32,6 @@ class ServiceProvider {
              okClient: OkHttpClient? = null,
              audioRecorder: AudioRecorder = AudioRecorderImpl(context)): Service {
         val converter = Converter(getHeaders(context), Gson())
-        AndroidThreeTen.init(context)
         val client = createClient(config, generateOkHttpClient(okClient), converter)
         return ServiceImpl(client, audioRecorder, converter, config.userId, TokenManager(config.refreshToken))
     }

--- a/library/src/main/java/com/voysis/sevice/TokenManager.kt
+++ b/library/src/main/java/com/voysis/sevice/TokenManager.kt
@@ -1,12 +1,13 @@
 package com.voysis.sevice
 
+import com.voysis.generateISODate
+import com.voysis.generateRFCDate
 import com.voysis.model.request.Token
-import org.threeten.bp.LocalDateTime
-import org.threeten.bp.format.DateTimeFormatter
+import java.util.Calendar
+import java.util.Date
 
 internal class TokenManager(val refreshToken: String) {
     internal var sessionToken: Token? = null
-    private var formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX")
 
     val token: String
         get() {
@@ -17,9 +18,24 @@ internal class TokenManager(val refreshToken: String) {
         return if (sessionToken == null) {
             false
         } else {
-            val currentTime = LocalDateTime.now()
-            val expiryDate = LocalDateTime.parse(sessionToken?.expiresAt!!, formatter).minusSeconds(30)
-            expiryDate.isAfter(currentTime)
+            val cal = Calendar.getInstance()
+            val currentTime = cal.time
+            cal.time = parseExpiresAtDate(sessionToken?.expiresAt!!)
+            cal.add(Calendar.SECOND, -30)
+            val expiryDate = cal.time
+            expiryDate.after(currentTime)
+        }
+    }
+
+    /*
+     * This uses a try catch to account for the following SimpleDateFormat parse exception
+     * that occurs on older api levels: IllegalArgumentException: Unknown pattern character 'X'
+     */
+    private fun parseExpiresAtDate(expiresAt: String): Date {
+        return try {
+            generateISODate(expiresAt)
+        } catch (e: Exception) {
+            generateRFCDate(expiresAt)
         }
     }
 }


### PR DESCRIPTION
we added in the com.jakewharton.threetenabp:threetenabp:1.1.1 library go get over date format issues we were experiencing between new and old android api versions. In theory it seemed like a great idea, but, It causes a memory leak every time `AndroidThreeTen.init(context)` was called so I'm reverting to the original fix i had in place for the issue.