### PR TITLE
Improve exception handling

### DIFF
--- a/library/src/main/java/com/voysis/sevice/ServiceImpl.kt
+++ b/library/src/main/java/com/voysis/sevice/ServiceImpl.kt
@@ -163,7 +163,11 @@ internal class ServiceImpl(private val client: Client,
 
     private fun handleException(callback: Callback, e: Exception) {
         recorder.stop()
-        callback.failure(VoysisException(e))
+        when {
+            e is VoysisException -> callback.failure(e)
+            e.cause is VoysisException -> callback.failure(e.cause as VoysisException)
+            else -> callback.failure(VoysisException(e))
+        }
         state = State.IDLE
     }
 }


### PR DESCRIPTION
We're currently wrapping all returned exceptions in a VoysisException which is unnecessary if the exception is already an instance of a VoysisException. This is misleading for the client because they end up with exception's wrapped in exceptions.  
To fix I Added check in handleException to return correct VoysisException to client if the exception or cause are instances of VoysisException.