### PR TITLE
Record audio immediately 

### DIFF
--- a/library/src/main/java/com/voysis/recorder/AudioPlayer.kt
+++ b/library/src/main/java/com/voysis/recorder/AudioPlayer.kt
@@ -8,10 +8,9 @@ class AudioPlayer(private val context: Context,
                   private var audioStart: MediaPlayer? = MediaPlayer.create(context, R.raw.voysis_on),
                   private var audioStop: MediaPlayer? = MediaPlayer.create(context, R.raw.voysis_off)) {
 
-    fun playStartAudio(callback: () -> Unit) {
+    fun playStartAudio() {
         audioStart = audioStart ?: MediaPlayer.create(context, R.raw.voysis_on)
         audioStart?.setOnCompletionListener {
-            callback()
             audioStart?.reset()
             audioStart?.release()
             audioStart = null

--- a/library/src/main/java/com/voysis/recorder/AudioRecorderImpl.kt
+++ b/library/src/main/java/com/voysis/recorder/AudioRecorderImpl.kt
@@ -31,9 +31,8 @@ class AudioRecorderImpl(context: Context,
         stopRecorder()
         record = record ?: createAudioRecorder()
         inProgress.set(true)
-        player.playStartAudio {
-            execute(callback)
-        }
+        execute(callback)
+        player.playStartAudio()
     }
 
     private fun execute(callback: OnDataResponse) {

--- a/library/src/test/java/com/voysis/sdk/AudioRecorderTest.kt
+++ b/library/src/test/java/com/voysis/sdk/AudioRecorderTest.kt
@@ -6,7 +6,6 @@ import android.media.AudioRecord
 import android.media.AudioRecord.RECORDSTATE_RECORDING
 import android.media.AudioRecord.RECORDSTATE_STOPPED
 import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.anyOrNull
 import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
@@ -53,9 +52,8 @@ class AudioRecorderTest {
 
     @Test
     fun testRecordingStart() {
-        callCompletionListener()
         audioRecorder.start(onDataResposne)
-        verify(player).playStartAudio(any())
+        verify(player).playStartAudio()
         verify(executorService).execute(any())
     }
 
@@ -68,24 +66,12 @@ class AudioRecorderTest {
 
     @Test
     fun testReadLoop() {
-        callCompletionListener()
         doAnswer { invocation ->
             (invocation.getArgument<Any>(0) as Runnable).run()
             null
         }.whenever(executorService).execute(ArgumentMatchers.any(Runnable::class.java))
         audioRecorder.start(onDataResposne)
         verify(onDataResposne).onDataResponse(any())
-        verify(onDataResposne).onComplete()
-    }
-
-    @Test
-    fun testOnCompleteCalledWheStopRecordingBeforeSoundBiteCompletes() {
-        doAnswer { invocation ->
-            audioRecorder.stop()
-            (invocation.getArgument<Any>(0) as () -> Unit).invoke()
-        }.whenever(player).playStartAudio(anyOrNull())
-        audioRecorder.start(onDataResposne)
-        verify(onDataResposne, times(0)).onDataResponse(any())
         verify(onDataResposne).onComplete()
     }
 
@@ -98,11 +84,5 @@ class AudioRecorderTest {
         assertEquals(audioInfoB.bitsPerSample, 8)
         val audioInfoC = audioRecorder.getAudioInfo()
         assertEquals(audioInfoC.bitsPerSample, -1)
-    }
-
-    private fun callCompletionListener() {
-        doAnswer { invocation ->
-            (invocation.getArgument<Any>(0) as () -> Unit).invoke()
-        }.whenever(player).playStartAudio(anyOrNull())
     }
 }


### PR DESCRIPTION
Removed callback from playStartAudio(). Calling execute() before playStartAudio to ensure that all audio is recorded when user clicks button.