### PR TITLE
wake word performance improvement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/library/src/main/java/com/voysis/api/ServiceProvider.kt
+++ b/library/src/main/java/com/voysis/api/ServiceProvider.kt
@@ -97,8 +97,8 @@ class ServiceProvider {
                      converter: Converter = Converter(getHeaders(context), Gson())): Service {
         val client = clientProvider.createClient()
         val recorder = generateRecorder(audioRecorder, config, context)
-        return when {
-            config.serviceType == ServiceType.WAKEWORD -> {
+        return when (config.serviceType) {
+            ServiceType.WAKEWORD -> {
                 val wakeWordDetector = makeWakeWordDetector(context, config.resourcePath!!, DetectorType.SINGLE)
                 val service = ServiceImpl(client, recorder, converter, config.userId, tokenManager)
                 return WakeWordServiceImpl(recorder, wakeWordDetector, service)

--- a/library/src/main/java/com/voysis/recorder/AudioRecorder.kt
+++ b/library/src/main/java/com/voysis/recorder/AudioRecorder.kt
@@ -26,4 +26,6 @@ interface AudioRecorder {
     fun start(): ReadableByteChannel
 
     fun mimeType(): MimeType?
+
+    fun getSource(): SourceManager
 }

--- a/library/src/main/java/com/voysis/recorder/AudioRecorderImpl.kt
+++ b/library/src/main/java/com/voysis/recorder/AudioRecorderImpl.kt
@@ -23,11 +23,11 @@ class AudioRecorderImpl(recordParams: AudioRecordParams,
     @Synchronized
     override fun start(): ReadableByteChannel {
         if (!source.isActive()) {
-            val pipe = Pipe.open()
-            readChannel = pipe.source()
             source.startRecording()
-            executor.execute { write(pipe.sink()) }
         }
+        val pipe = Pipe.open()
+        readChannel = pipe.source()
+        executor.execute { write(pipe.sink()) }
         return readChannel
     }
 
@@ -35,6 +35,8 @@ class AudioRecorderImpl(recordParams: AudioRecordParams,
     override fun stop() = source.destroy()
 
     override fun mimeType(): MimeType? = source.generateMimeType()
+
+    override fun getSource(): SourceManager = source
 
     override fun registerWriteListener(listener: (ByteBuffer) -> Unit) {
         this.listener = listener

--- a/library/src/main/java/com/voysis/recorder/SourceManager.kt
+++ b/library/src/main/java/com/voysis/recorder/SourceManager.kt
@@ -25,14 +25,18 @@ class SourceManager(private var audio: AudioRecordFactory, private val recordPar
     fun isRecording(): Boolean = isActive.get() && record.recordingState == AudioRecord.RECORDSTATE_RECORDING
 
     fun destroy() {
-        if (record.state != AudioRecord.STATE_UNINITIALIZED) {
-            isActive.set(false)
+        if (::record.isInitialized && record.state != AudioRecord.STATE_UNINITIALIZED) {
             record.stop()
             record.release()
         }
+        isActive.set(false)
     }
 
     fun read(buffer: ByteArray, i: Int, size: Int): Int {
+        return record.read(buffer, i, size)
+    }
+
+    fun read(buffer: ShortArray, i: Int, size: Int): Int {
         return record.read(buffer, i, size)
     }
 }

--- a/library/src/main/java/com/voysis/recorder/WavAudioRecorder.kt
+++ b/library/src/main/java/com/voysis/recorder/WavAudioRecorder.kt
@@ -28,6 +28,10 @@ class WavAudioRecorder(var wavFile: File? = null,
 
     override fun mimeType(): MimeType? = MimeType(16000, 16, "signed-int", false, 1)
 
+    override fun getSource(): SourceManager {
+       throw NotImplementedError("this operation is not permitted")
+    }
+
     @Synchronized
     override fun stop() {
     }

--- a/library/src/main/java/com/voysis/recorder/WavAudioRecorder.kt
+++ b/library/src/main/java/com/voysis/recorder/WavAudioRecorder.kt
@@ -29,7 +29,7 @@ class WavAudioRecorder(var wavFile: File? = null,
     override fun mimeType(): MimeType? = MimeType(16000, 16, "signed-int", false, 1)
 
     override fun getSource(): SourceManager {
-       throw NotImplementedError("this operation is not permitted")
+        throw NotImplementedError("this operation is not permitted")
     }
 
     @Synchronized

--- a/library/src/main/java/com/voysis/wakeword/WakeWordDetector.kt
+++ b/library/src/main/java/com/voysis/wakeword/WakeWordDetector.kt
@@ -1,7 +1,7 @@
 package com.voysis.wakeword
 
 import com.voysis.events.WakeWordState
-import java.nio.channels.ReadableByteChannel
+import com.voysis.recorder.SourceManager
 
 interface WakeWordDetector {
 
@@ -10,7 +10,7 @@ interface WakeWordDetector {
      * @param source audio source used for detection
      * @param callback notifies user of wakeword state
      */
-    fun listen(source: ReadableByteChannel, callback: (WakeWordState) -> Unit)
+    fun listen(source: SourceManager, callback: (WakeWordState) -> Unit)
 
     /**
      * stops wakeword

--- a/library/src/main/java/com/voysis/wakeword/WakeWordServiceImpl.kt
+++ b/library/src/main/java/com/voysis/wakeword/WakeWordServiceImpl.kt
@@ -19,8 +19,7 @@ internal class WakeWordServiceImpl(private val recorder: AudioRecorder,
 
     override fun startListening(callback: Callback, context: Map<String, Any>?, interactionType: InteractionType?) {
         if (state == State.IDLE) {
-            val pipe = recorder.start()
-            wakeword.listen(pipe) {
+            wakeword.listen(recorder.getSource()) {
                 callback.wakeword(it)
                 if (it == WakeWordState.DETECTED) {
                     serviceImpl.startAudioQuery(callback, context, interactionType)


### PR DESCRIPTION
Passing sourceManager instead of readableByteChannel to wakewordDetectorImpl as we can read shorts and the amount we require directly from audio source so no unnecessary conversion is needed for prepossessing.