### PR TITLE
destroy old recorder if exists before creating new one

### DIFF
--- a/library/src/main/java/com/voysis/recorder/AudioSource.kt
+++ b/library/src/main/java/com/voysis/recorder/AudioSource.kt
@@ -11,9 +11,10 @@ class AudioSource(private var audio: AudioRecordFactory, private val recordParam
     fun isActive(): Boolean = isActive.get()
 
     fun startRecording() {
-        isActive.set(true)
+        destroy()
         record = audio.make()
         record?.startRecording()
+        isActive.set(true)
     }
 
     fun generateMimeType(): MimeType? {

--- a/library/src/main/java/com/voysis/recorder/AudioSource.kt
+++ b/library/src/main/java/com/voysis/recorder/AudioSource.kt
@@ -4,7 +4,7 @@ import android.media.AudioRecord
 import com.voysis.generateMimeType
 import java.util.concurrent.atomic.AtomicBoolean
 
-class AudioSource(private var audio: AudioRecordFactory, private val recordParams: AudioRecordParams) {
+class AudioSource(private var source: AudioRecordFactory, private val recordParams: AudioRecordParams) {
     private val isActive = AtomicBoolean(false)
     private var record: AudioRecord? = null
 
@@ -12,7 +12,7 @@ class AudioSource(private var audio: AudioRecordFactory, private val recordParam
 
     fun startRecording() {
         destroy()
-        record = audio.make()
+        record = source.make()
         record?.startRecording()
         isActive.set(true)
     }


### PR DESCRIPTION
its necessary to destroy() the old recorder before creating a new one. This call was in the the audioRecordImpl class but I must have removed it when moving audioRecord management to the audioSource class.