### PR TITLE
reorder state change variable onError

### DIFF
--- a/library/src/main/java/com/voysis/sevice/ServiceImpl.kt
+++ b/library/src/main/java/com/voysis/sevice/ServiceImpl.kt
@@ -162,13 +162,13 @@ internal class ServiceImpl(private val client: Client,
 
     private fun handleException(callback: Callback, e: Exception) {
         recorder.stop()
+        state = State.IDLE
         recordingFinishedCheck(callback, e)
         when {
             e is VoysisException -> callback.failure(e)
             e.cause is VoysisException -> callback.failure(e.cause as VoysisException)
             else -> callback.failure(VoysisException(e))
         }
-        state = State.IDLE
     }
 
     //If cancellation exception is thrown at any stage before recording finishes we track the callback here

--- a/library/src/main/java/com/voysis/wakeword/WakeWordDetectorImpl.kt
+++ b/library/src/main/java/com/voysis/wakeword/WakeWordDetectorImpl.kt
@@ -41,7 +41,7 @@ class WakeWordDetectorImpl(private val recorder: AudioRecorder,
         executor.execute {
             state.set(ACTIVE)
             callback.invoke(state.get())
-            processWakeWord(callback)
+            processWakeWord()
         }
     }
 
@@ -56,7 +56,7 @@ class WakeWordDetectorImpl(private val recorder: AudioRecorder,
         recorder.stop()
     }
 
-    private fun processWakeWord(callback: (WakeWordState) -> Unit) {
+    private fun processWakeWord() {
         val ringBuffer = CircularFifoBuffer(sampleSize)
         val shortArray = ShortArray(sampleWindowSize)
         val source = recorder.source
@@ -73,7 +73,7 @@ class WakeWordDetectorImpl(private val recorder: AudioRecorder,
                     count = if (processWakeword(input)) count + 1 else 0
                     if (count == detectionThreshold) {
                         state.set(DETECTED)
-                        callback.invoke(state.get())
+                        callback?.invoke(state.get())
                         ringBuffer.clear()
                         if (type == DetectorType.SINGLE) {
                             return
@@ -84,7 +84,7 @@ class WakeWordDetectorImpl(private val recorder: AudioRecorder,
             }
         }
         state.set(IDLE)
-        callback.invoke(state.get())
+        callback?.invoke(state.get())
     }
 
     private fun processWakeword(input: FloatArray): Boolean {


### PR DESCRIPTION
moved state change to before callbacks so future calls see correct state.
removed unnecessary callback method param 