### PR TITLE
Update activation threshold mechanism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ if ("unspecified" == version) {
 }
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.61'
     repositories {
         google()
         jcenter()

--- a/library/src/main/java/com/voysis/sevice/DataConfig.kt
+++ b/library/src/main/java/com/voysis/sevice/DataConfig.kt
@@ -13,4 +13,4 @@ data class DataConfig(override val isVadEnabled: Boolean = true,
                       override val audioRecordParams: AudioRecordParams? = null,
                       override val interactionType: InteractionType = InteractionType.QUERY,
                       override val serviceType: ServiceType = ServiceType.DEFAULT,
-                      override val resourcePath: String) : Config
+                      override val resourcePath: String = "") : Config

--- a/library/src/main/java/com/voysis/wakeword/Utils.kt
+++ b/library/src/main/java/com/voysis/wakeword/Utils.kt
@@ -1,0 +1,23 @@
+package com.voysis.wakeword
+
+import org.apache.commons.collections.buffer.CircularFifoBuffer
+import org.tensorflow.lite.Interpreter
+
+fun processWakeword(buffer: CircularFifoBuffer, interpreter: Interpreter): Float {
+    val input = buffer.toArray().map { it as Float }.toFloatArray()
+    val output = Array(1) { FloatArray(2) }
+    interpreter.run(input, output)
+    return output[0][1]
+}
+
+fun isAboveThreshold(input: Float, threshold: Float): Int = if (input >= threshold) {
+    1
+} else {
+    0
+}
+
+
+fun detected(countQueue: CircularFifoBuffer, leftThreshold: Int): Boolean {
+    val count = countQueue.toArray().map { it as Int }.toIntArray()
+    return count.filter { it == 1 }.size > leftThreshold * 0.5
+}

--- a/library/src/main/java/com/voysis/wakeword/Utils.kt
+++ b/library/src/main/java/com/voysis/wakeword/Utils.kt
@@ -10,7 +10,7 @@ fun processWakeword(buffer: CircularFifoBuffer, interpreter: Interpreter): Float
     return output[0][1]
 }
 
-fun isAboveThreshold(input: Float, threshold: Float): Int = if (input >= threshold) {
+fun isAboveThreshold(input: Float, threshold: Float): Int = if (input >= threshold) 1 else 0
     1
 } else {
     0

--- a/library/src/main/java/com/voysis/wakeword/Utils.kt
+++ b/library/src/main/java/com/voysis/wakeword/Utils.kt
@@ -11,10 +11,6 @@ fun processWakeword(buffer: CircularFifoBuffer, interpreter: Interpreter): Float
 }
 
 fun isAboveThreshold(input: Float, threshold: Float): Int = if (input >= threshold) 1 else 0
-    1
-} else {
-    0
-}
 
 fun detected(countQueue: CircularFifoBuffer, leftThreshold: Int): Boolean {
     val count = countQueue.toArray().map { it as Int }.toIntArray()

--- a/library/src/main/java/com/voysis/wakeword/WakeWordDetectorImpl.kt
+++ b/library/src/main/java/com/voysis/wakeword/WakeWordDetectorImpl.kt
@@ -58,7 +58,7 @@ class WakeWordDetectorImpl(private val recorder: AudioRecorder,
                 for (i in 0 until requestedSampleSize) {
                     ringBuffer.add(shortArray[i].toFloat())
                 }
-                if (ringBuffer.size >=  config.sampleSize) {
+                if (ringBuffer.size >= config.sampleSize) {
                     val result = processWakeword(ringBuffer, interpreter)
                     countQueue.add(isAboveThreshold(result, config.probThreshold))
                     if (detected(countQueue, config.thresholdCount)) {
@@ -77,9 +77,11 @@ class WakeWordDetectorImpl(private val recorder: AudioRecorder,
         callback?.invoke(state.get())
     }
 
-    private fun getRequestedSampleSize(ringBuffer: CircularFifoBuffer, requestedSampleSize: Int) = if (!ringBuffer.isFull && ringBuffer.size + requestedSampleSize > config.sampleSize) {
-        config.sampleSize - ringBuffer.size
-    } else {
-        requestedSampleSize
+    private fun getRequestedSampleSize(ringBuffer: CircularFifoBuffer, requestedSampleSize: Int): Int {
+        return if (!ringBuffer.isFull && ringBuffer.size + requestedSampleSize > config.sampleSize) {
+            config.sampleSize - ringBuffer.size
+        } else {
+            requestedSampleSize
+        }
     }
 }

--- a/library/src/main/java/com/voysis/wakeword/WakeWordDetectorImpl.kt
+++ b/library/src/main/java/com/voysis/wakeword/WakeWordDetectorImpl.kt
@@ -59,8 +59,8 @@ class WakeWordDetectorImpl(private val recorder: AudioRecorder,
                     ringBuffer.add(shortArray[i].toFloat())
                 }
                 if (ringBuffer.size >= config.sampleSize) {
-                    val result = processWakeword(ringBuffer, interpreter)
-                    countQueue.add(isAboveThreshold(result, config.probThreshold))
+                    val output = processWakeword(ringBuffer, interpreter)
+                    countQueue.add(isAboveThreshold(output, config.probThreshold))
                     if (detected(countQueue, config.thresholdCount)) {
                         state.set(DETECTED)
                         callback?.invoke(state.get())

--- a/library/src/main/java/com/voysis/wakeword/WakewordConfig.kt
+++ b/library/src/main/java/com/voysis/wakeword/WakewordConfig.kt
@@ -7,5 +7,5 @@ data class WakewordConfig(
         val sampleSize: Int = 24000,
         //interpreter output needs to be above this threshold in order for activation to be recognised
         val probThreshold: Float = 0.55f,
-        //ammount of activations that need to be registered before detection registered
+        //amount of activations that need to be registered before detection registered
         val thresholdCount: Int = 11)

--- a/library/src/test/java/com/voysis/sdk/WakewordDetectorTest.kt
+++ b/library/src/test/java/com/voysis/sdk/WakewordDetectorTest.kt
@@ -11,6 +11,9 @@ import com.voysis.recorder.AudioRecorderImpl
 import com.voysis.recorder.AudioSource
 import com.voysis.wakeword.WakeWordDetector
 import com.voysis.wakeword.WakeWordDetectorImpl
+import com.voysis.wakeword.detected
+import com.voysis.wakeword.isAboveThreshold
+import org.apache.commons.collections.buffer.CircularFifoBuffer
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -87,5 +90,35 @@ class WakewordDetectorTest : ClientTest() {
             buffer.put(0)
             i++
         }
+    }
+
+    @Test
+    fun testWakewordActivation() {
+        var probabilities = listOf(0.1f, 0.1f, 0.1f, 0.5f, 0.5f, 0.5f, 0.1f, 0.1f, 0.1f)
+        Assert.assertEquals(probabilitiesToActivationsWithContext(probabilities, 0.5f, 3), 3)
+        Assert.assertEquals(probabilitiesToActivationsWithContext(probabilities, 0.5f, 4), 2)
+        Assert.assertEquals(probabilitiesToActivationsWithContext(probabilities, 0.55f, 3), 0)
+        Assert.assertEquals(probabilitiesToActivationsWithContext(probabilities, 0.1f, 3), 6)
+        probabilities = listOf(0.0356333f, 0.031588446f, 0.031266436f, 0.02904712f, 0.032489043f, 0.026997248f, 0.029406862f, 0.02489764f, 0.029734029f, 0.024640385f, 0.03177711f, 0.028833939f, 0.036821257f, 0.0391036f, 0.052728474f, 0.03529741f, 0.041453764f, 0.028011154f, 0.034597237f, 0.024858817f, 0.02883305f, 0.02245944f, 0.031966653f, 0.03177742f, 0.04432046f, 0.04002099f, 0.040271714f, 0.0382619f, 0.035585098f, 0.030636195f, 0.023181543f, 0.028756317f, 0.044512182f, 0.061714098f, 0.1539415f, 0.23393238f, 0.34523478f, 0.5102445f, 0.66894656f, 0.75178576f, 0.7967912f, 0.8377506f, 0.8416338f, 0.917356f, 0.9224794f, 0.9535297f, 0.94170445f, 0.96369725f, 0.9570479f, 0.97133696f, 0.9577936f, 0.96862686f, 0.9565326f, 0.96527684f, 0.9494574f, 0.9604444f, 0.94931513f, 0.95819664f, 0.9480984f, 0.9541109f, 0.9446847f, 0.9563497f, 0.94704056f, 0.9477755f, 0.9379421f, 0.9392767f, 0.9221256f, 0.950618f, 0.9142939f, 0.9322532f, 0.8050973f, 0.6294255f, 0.39060998f, 0.18650427f, 0.0545912f, 0.0155734895f, 0.010198834f, 0.0065746745f, 0.006712006f, 0.007182035f, 0.010279924f, 0.008469432f, 0.008866795f, 0.011126339f, 0.012798452f, 0.010853377f, 0.011233264f, 0.009790641f, 0.009224032f, 0.00836302f, 0.007906925f, 0.008777731f, 0.008078391f, 0.007237932f, 0.007217334f, 0.0076291915f, 0.0076369676f, 0.00749962f, 0.0076394803f, 0.00809427f, 0.008183744f, 0.008512603f, 0.008308798f, 0.009079428f, 0.009024824f, 0.009467147f, 0.009468399f, 0.009395005f, 0.00971932f, 0.009348406f)
+        Assert.assertEquals(probabilitiesToActivationsWithContext(probabilities, 0.55f, 11), 34)
+        Assert.assertEquals(probabilitiesToActivationsWithContext(probabilities, 0.95f, 11), 12)
+
+    }
+
+    private fun probabilitiesToActivationsWithContext(probabilities: List<Float>, probThreshold: Float, leftThreshold: Int): Int {
+        var numActivations = 0
+        val predictions = mutableListOf<Int>()
+        for (item in probabilities) {
+            predictions.add(isAboveThreshold(item, probThreshold))
+        }
+
+        for (i in leftThreshold until predictions.size step 1) {
+            val bufferedWindow = predictions.subList(i - leftThreshold, i)
+            val x = CircularFifoBuffer(bufferedWindow)
+            if (detected(x, leftThreshold)) {
+                numActivations++
+            }
+        }
+        return numActivations
     }
 }


### PR DESCRIPTION
Currently we detect activations using a count variable incremented every time a detection is recognised. Old wakeword model returns 1 or 0 depending on activation. New model returns more accurate float value. We are replacing the count variable with an activation queue with configurable size. Float output threshold also configurable. 

On every loop iteration we check the condition of the queue and register detection if the condition is satisfied