### PR TITLE
Dev ethan eng 2385 reduce copying of model files

### DIFF
--- a/library/src/main/java/com/voysis/client/provider/ModelFileProvider.kt
+++ b/library/src/main/java/com/voysis/client/provider/ModelFileProvider.kt
@@ -18,7 +18,7 @@ internal interface ModelFileProvider {
      * @param fName file Name to extract
      * @return model extracted file location
      */
-    fun extractModel(fName: String): String
+    fun extractModel(fName: String, subDir: String? = null): String
 }
 
 /**
@@ -32,21 +32,18 @@ internal class LocalModelAssetProvider(context: Context,
                                        private val filesDir: String = context.filesDir.absolutePath.toString(),
                                        private val assetManager: AssetManager = context.assets) : ModelFileProvider {
 
-    override fun extractModel(fName: String): String {
+    private val processedFiles = mutableSetOf<String>()
+
+    override fun extractModel(fName: String, subDir: String?): String {
         try {
-            var fullPath: String
-            val assets = assetManager.list(fName)
+            val fullPath = filesDir.plus("/").plus(fName).plus("/")
+            val assetPath = if (subDir != null) fName.plus("/$subDir") else fName
+            val assets = assetManager.list(assetPath)
             if (assets!!.isEmpty()) {
-                fullPath = fName
-                copyFile(fName)
+                copyFile(assetPath)
             } else {
-                fullPath = filesDir.plus("/").plus(fName)
-                val dir = File(fullPath)
-                fullPath = fullPath.plus("/")
-                if (!dir.exists())
-                    dir.mkdir()
                 for (i in assets.indices) {
-                    extractModel(fName.plus("/").plus(assets[i]))
+                    extractModel(assetPath.plus("/").plus(assets[i]))
                 }
             }
             return fullPath
@@ -59,12 +56,34 @@ internal class LocalModelAssetProvider(context: Context,
     private fun copyFile(filename: String) {
         try {
             val newFileName = filesDir.plus("/").plus(filename)
+            val file = File(newFileName)
+            val dir = File(file.parent!!)
+            if (!dir.exists()) {
+                dir.mkdirs()
+            }
+            if (file.exists()) {
+                Log.println(Log.VERBOSE, "LocalModelAssetProvider", "File: $filename already exists in path: $filesDir")
+                processedFiles.add(newFileName)
+                return
+            } else {
+                deleteFilesInDir(dir)
+            }
             val copiedFileOutput = FileOutputStream(newFileName)
             assetManager.open(filename).copyTo(copiedFileOutput, 4096)
             copiedFileOutput.flush()
             copiedFileOutput.close()
+            processedFiles.add(newFileName)
         } catch (e: Exception) {
-            Log.e("AssetProvider", "error copying file", e)
+            Log.e("AssetProvider", "Error copying file: $filename", e)
+        }
+    }
+
+    private fun deleteFilesInDir(dir: File) {
+        dir.listFiles()?.forEach {
+            if (!processedFiles.contains(it.path)) {
+                Log.println(Log.VERBOSE, "LocalModelAssetProvider", "Deleting file: ${it.name} from directory: $filesDir")
+                it.delete()
+            }
         }
     }
 }

--- a/library/src/main/java/com/voysis/client/provider/ModelFileProvider.kt
+++ b/library/src/main/java/com/voysis/client/provider/ModelFileProvider.kt
@@ -62,7 +62,6 @@ internal class LocalModelAssetProvider(context: Context,
                 dir.mkdirs()
             }
             if (file.exists()) {
-                Log.println(Log.VERBOSE, "LocalModelAssetProvider", "File: $filename already exists in path: $filesDir")
                 processedFiles.add(newFileName)
                 return
             } else {
@@ -81,7 +80,6 @@ internal class LocalModelAssetProvider(context: Context,
     private fun deleteFilesInDir(dir: File) {
         dir.listFiles()?.forEach {
             if (!processedFiles.contains(it.path)) {
-                Log.println(Log.VERBOSE, "LocalModelAssetProvider", "Deleting file: ${it.name} from directory: $filesDir")
                 it.delete()
             }
         }

--- a/library/src/main/java/com/voysis/client/provider/TfLiteModelProvider.kt
+++ b/library/src/main/java/com/voysis/client/provider/TfLiteModelProvider.kt
@@ -1,0 +1,24 @@
+package com.voysis.client.provider
+
+import android.content.res.AssetFileDescriptor
+import android.content.res.AssetManager
+import org.tensorflow.lite.Interpreter
+import java.io.FileInputStream
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+
+class TfLiteModelProvider(private val resourcePath: String, private var assetManager: AssetManager) {
+
+    fun createTfLiteInterpreter(path: String): Interpreter {
+        return Interpreter(loadTfLiteFile(path))
+    }
+
+    private fun loadTfLiteFile(modelPath: String): ByteBuffer {
+        val fileDescriptor: AssetFileDescriptor = assetManager.openFd("$resourcePath/".plus(modelPath))
+        val inputStream = FileInputStream(fileDescriptor.fileDescriptor)
+        val fileChannel: FileChannel = inputStream.channel
+        val startOffset: Long = fileDescriptor.startOffset
+        val declaredLength: Long = fileDescriptor.declaredLength
+        return fileChannel.map(FileChannel.MapMode.READ_ONLY, startOffset, declaredLength)
+    }
+}


### PR DESCRIPTION
Updated ModelFileLoader to only copy files from assets if we haven't got it already in local storage. Also added the option to set a subdir to copy from rather than copying all of `resources`. In this case we set the subdirectory to models so only files inside here are copied
The structure of the models directory looks like: 
```
models/am/01CSMFXH449RGN0T0ZZN7F08Z2
models/am/01DA3PB7N9PWY1147WHSHM0E6W
models/am/01DA3PEBT79HZY1M29S9RB1TY9
models/lm/01DAGYYYFE77F710PRM6P306B4
```

When copying a file into a directory we check for any files that haven't been processed already and delete them.

As part of this change all other files including `.tflite` files will be read directly from Assets