### PR TITLE
Dev ethan eng 2390 include raw lm output

### DIFF
--- a/library/src/main/java/com/voysis/model/response/Response.kt
+++ b/library/src/main/java/com/voysis/model/response/Response.kt
@@ -23,7 +23,7 @@ data class Links(@field:SerializedName("self") val self: Self? = null,
                  @field:SerializedName("queries") val queries: Queries? = null,
                  @field:SerializedName("audio") val audio: Audio? = null)
 
-data class TextQuery(@field:SerializedName("text") val text: String? = null)
+data class TextQuery(@field:SerializedName("text") val text: String? = null, @field:SerializedName("lmOutput") val lmOutput: String? = text)
 
 data class AudioQuery(@field:SerializedName("mimeType") val mimeType: String? = "audio/pcm;bits=16;rate=16000")
 

--- a/library/src/test/java/com/voysis/android/core/impl/WebSocketClientTest.kt
+++ b/library/src/test/java/com/voysis/android/core/impl/WebSocketClientTest.kt
@@ -67,7 +67,7 @@ class WebSocketClientTest : ClientTest() {
     @Test
     fun testExecuteTextQuery() {
         webSocketClient.sendTextQuery(null, interactionType, "text", "1", "123")
-        val textEntity = """"entity":{"interactionType":"QUERY","userId":"1","queryType":"text","textQuery":{"text":"text"},"locale":"en-US"},"requestId":"2","type":"request","method":"POST"}"""
+        val textEntity = """"entity":{"interactionType":"QUERY","userId":"1","queryType":"text","textQuery":{"text":"text","lmOutput":"text"},"locale":"en-US"},"requestId":"2","type":"request","method":"POST"}"""
         argumentCaptor<String>().apply {
             verify(webSocket).send(capture())
             assertTrue(firstValue.contains(textEntity))


### PR DESCRIPTION
Added the `lmOutput` field to StreamResponse so we can display the rawLmOutput before we strip tags. By default when this object is first created we set the `lmOutput`=`text` since text has not been stripped yet. 